### PR TITLE
Add Track MBID if present in the Plex Webhook POST

### DIFF
--- a/src/lib/helpers/generateListenbrainzBody.ts
+++ b/src/lib/helpers/generateListenbrainzBody.ts
@@ -19,7 +19,7 @@ const generateListenbrainzBody = (body: Payload) => {
 				}
 			}
 		]
-	})
+	});
 };
 
 export default generateListenbrainzBody;

--- a/src/lib/helpers/generateListenbrainzBody.ts
+++ b/src/lib/helpers/generateListenbrainzBody.ts
@@ -13,7 +13,10 @@ const generateListenbrainzBody = (body: Payload) => {
 					},
 					artist_name: body.Metadata.originalTitle ?? body.Metadata.grandparentTitle,
 					track_name: body.Metadata.title,
-					release_name: body.Metadata.parentTitle
+					release_name: body.Metadata.parentTitle,
+					...(body.Metadata?.Guid?.[0]?.id !== undefined && {
+                        track_mbid: body.Metadata.Guid[0].id.replace(/^mbid:\/\//, '')
+                    })
 				}
 			}
 		]

--- a/src/lib/helpers/generateListenbrainzBody.ts
+++ b/src/lib/helpers/generateListenbrainzBody.ts
@@ -2,7 +2,7 @@ import type Payload from '$lib/typing/payload';
 
 // generate the body required by LB: https://listenbrainz.readthedocs.io/en/latest/dev/json/#submission-json
 const generateListenbrainzBody = (body: Payload) => {
-	let track_mbid = body.Metadata?.Guid?.find((v) => v.id?.startsWith("mbid://"))?.id?.substring(7);
+	const track_mbid = body.Metadata?.Guid?.find((v) => v.id?.startsWith("mbid://"))?.id?.substring(7);
 	return JSON.stringify({
 		listen_type: body.event === 'media.scrobble' ? 'single' : 'playing_now',
 		payload: [
@@ -10,12 +10,12 @@ const generateListenbrainzBody = (body: Payload) => {
 				listened_at: body.event === 'media.scrobble' ? Math.floor(Date.now() / 1000) : undefined,
 				track_metadata: {
 					additional_info: {
-						listening_from: 'Plex'
+						listening_from: 'Plex',
+					  ...(track_mbid !== undefined && { track_mbid: track_mbid })
 					},
 					artist_name: body.Metadata.originalTitle ?? body.Metadata.grandparentTitle,
 					track_name: body.Metadata.title,
 					release_name: body.Metadata.parentTitle,
-					...(track_mbid !== undefined && { track_mbid: track_mbid })
 				}
 			}
 		]

--- a/src/lib/helpers/generateListenbrainzBody.ts
+++ b/src/lib/helpers/generateListenbrainzBody.ts
@@ -11,7 +11,7 @@ const generateListenbrainzBody = (body: Payload) => {
 				track_metadata: {
 					additional_info: {
 						listening_from: 'Plex',
-					  ...(track_mbid !== undefined && { track_mbid: track_mbid })
+					  track_mbid: track_mbid
 					},
 					artist_name: body.Metadata.originalTitle ?? body.Metadata.grandparentTitle,
 					track_name: body.Metadata.title,

--- a/src/lib/helpers/generateListenbrainzBody.ts
+++ b/src/lib/helpers/generateListenbrainzBody.ts
@@ -2,7 +2,7 @@ import type Payload from '$lib/typing/payload';
 
 // generate the body required by LB: https://listenbrainz.readthedocs.io/en/latest/dev/json/#submission-json
 const generateListenbrainzBody = (body: Payload) => {
-	let track_mbid = body.Metadata?.Guid?.[0]?.id?.match(/mbid:\/\/([a-fA-F0-9\\-]*){1}\s*/)?.[0]
+	let track_mbid = body.Metadata?.Guid?.find((v) => v.id?.startsWith("mbid://"))?.id?.substring(7);
 
 	let payload = {
 		listen_type: body.event === 'media.scrobble' ? 'single' : 'playing_now',

--- a/src/lib/helpers/generateListenbrainzBody.ts
+++ b/src/lib/helpers/generateListenbrainzBody.ts
@@ -2,7 +2,9 @@ import type Payload from '$lib/typing/payload';
 
 // generate the body required by LB: https://listenbrainz.readthedocs.io/en/latest/dev/json/#submission-json
 const generateListenbrainzBody = (body: Payload) => {
-	return JSON.stringify({
+	let track_mbid = body.Metadata?.Guid?.[0]?.id?.match(/mbid:\/\/([a-fA-F0-9\\-]*){1}\s*/)?.[0]
+
+	let payload = {
 		listen_type: body.event === 'media.scrobble' ? 'single' : 'playing_now',
 		payload: [
 			{
@@ -14,13 +16,14 @@ const generateListenbrainzBody = (body: Payload) => {
 					artist_name: body.Metadata.originalTitle ?? body.Metadata.grandparentTitle,
 					track_name: body.Metadata.title,
 					release_name: body.Metadata.parentTitle,
-					...(body.Metadata?.Guid?.[0]?.id !== undefined && {
-                        track_mbid: body.Metadata.Guid[0].id.replace(/^mbid:\/\//, '')
-                    })
+					...(track_mbid !== undefined && { track_mbid: track_mbid })
 				}
 			}
 		]
-	});
+	}
+	console.log(JSON.stringify(payload));
+
+	return JSON.stringify(payload)
 };
 
 export default generateListenbrainzBody;

--- a/src/lib/helpers/generateListenbrainzBody.ts
+++ b/src/lib/helpers/generateListenbrainzBody.ts
@@ -15,7 +15,7 @@ const generateListenbrainzBody = (body: Payload) => {
 					},
 					artist_name: body.Metadata.originalTitle ?? body.Metadata.grandparentTitle,
 					track_name: body.Metadata.title,
-					release_name: body.Metadata.parentTitle,
+					release_name: body.Metadata.parentTitle
 				}
 			}
 		]

--- a/src/lib/helpers/generateListenbrainzBody.ts
+++ b/src/lib/helpers/generateListenbrainzBody.ts
@@ -3,8 +3,7 @@ import type Payload from '$lib/typing/payload';
 // generate the body required by LB: https://listenbrainz.readthedocs.io/en/latest/dev/json/#submission-json
 const generateListenbrainzBody = (body: Payload) => {
 	let track_mbid = body.Metadata?.Guid?.find((v) => v.id?.startsWith("mbid://"))?.id?.substring(7);
-
-	let payload = {
+	return JSON.stringify({
 		listen_type: body.event === 'media.scrobble' ? 'single' : 'playing_now',
 		payload: [
 			{
@@ -20,10 +19,7 @@ const generateListenbrainzBody = (body: Payload) => {
 				}
 			}
 		]
-	}
-	console.log(JSON.stringify(payload));
-
-	return JSON.stringify(payload)
+	})
 };
 
 export default generateListenbrainzBody;

--- a/src/lib/typing/payload.ts
+++ b/src/lib/typing/payload.ts
@@ -22,6 +22,7 @@ interface MetadataPayload {
 	key: string;
 	parentRatingKey: string;
 	grandparentRatingKey: string;
+	guid: string;
 	Guid?: GuidPayload[];
 	parentGuid: string;
 	grandparentGuid: string;

--- a/src/lib/typing/payload.ts
+++ b/src/lib/typing/payload.ts
@@ -13,13 +13,16 @@ interface PlayerPayload {
 	title: string;
 	uuid: string;
 }
+interface GuidPayload {
+	id: string;
+}
 interface MetadataPayload {
 	librarySectionType: string;
 	ratingKey: string;
 	key: string;
 	parentRatingKey: string;
 	grandparentRatingKey: string;
-	guid: string;
+	Guid?: GuidPayload[];
 	parentGuid: string;
 	grandparentGuid: string;
 	parentStudio: string;


### PR DESCRIPTION
I sniffed the webhooks of Plex for fun... Turns out properly MBID-tagged tracks do have MBID UUIDs sent in the webhook... Weird that nobody noticed. Here's an example webhook POST content:

```
{
    "event": "media.play",
    "user": true,
    "owner": true,
    "Account": {
        [redacted]
    },
    "Server": {
        [redacted]
    },
    "Player": {
        [redacted]
    },
    "Metadata": {
        "librarySectionType": "artist",
        "ratingKey": "75741",
        "key": "/library/metadata/75741",
        "parentRatingKey": "75740",
        "grandparentRatingKey": "64551",
        "guid": "plex://track/6622d12bf03cec061155e4cb",
        "parentGuid": "plex://album/6622d11af03cec06115354f9",
        "grandparentGuid": "plex://artist/5d07bc87403c640290518e59",
        "parentStudio": "Drum&BassArena",
        "type": "track",
        "title": "Two Fang",
        "grandparentKey": "/library/metadata/64551",
        "parentKey": "/library/metadata/75740",
        "librarySectionTitle": "Drum and Bass",
        "librarySectionID": 12,
        "librarySectionKey": "/library/sections/12",
        "grandparentTitle": "Spor",
        "parentTitle": "Two Fang",
        "summary": "",
        "index": 1,
        "parentIndex": 1,
        "ratingCount": 1100,
        "userRating": 9.0,
        "viewCount": 1,
        "lastViewedAt": 1718401196,
        "lastRatedAt": 1718401097,
        "parentYear": 2024,
        "thumb": "/library/metadata/75740/thumb/1718401062",
        "parentThumb": "/library/metadata/75740/thumb/1718401062",
        "grandparentThumb": "/library/metadata/64551/thumb/1718310361",
        "addedAt": 1718401059,
        "updatedAt": 1718401062,
        "musicAnalysisVersion": "1",
        "Guid": [
            {
                "id": "mbid://d3c67e4c-6589-4612-9efb-d6fb6a7b4db4"
            }
        ]
    }
}
```

And indeed, Metadata.Guid[0].id contains a beautiful MBID for a track... Which means we can submit it to the API and get actual Album information to ListenBrainz!

Anyways, I've patched a few things to add support for that. I am not that big in the TS territory, so if there's any cleanup to do, I'd advise someone else help me with this!

Cheers.