### PR TITLE
feat: add `media_player` to `additional_info`

### DIFF
--- a/src/lib/helpers/generateListenbrainzBody.ts
+++ b/src/lib/helpers/generateListenbrainzBody.ts
@@ -10,7 +10,8 @@ const generateListenbrainzBody = (body: Payload) => {
 				listened_at: body.event === 'media.scrobble' ? Math.floor(Date.now() / 1000) : undefined,
 				track_metadata: {
 					additional_info: {
-						listening_from: 'Plex',
+					  listening_from: 'Plex',
+					  media_player: 'Plex',
 					  track_mbid: track_mbid
 					},
 					artist_name: body.Metadata.originalTitle ?? body.Metadata.grandparentTitle,


### PR DESCRIPTION
This adds Plex as the `media_player` following [the `additional_info` documentation](https://listenbrainz.readthedocs.io/en/latest/users/json.html#id1).

I'm not sure if `listening_from` was an old equivalent to this (ah, `listening_from` was an old unofficial way of handling it, but [it was standardised to `media_player` in 2021](https://github.com/metabrainz/listenbrainz-server/pull/1607))? 🤔

I've kept the `listening_from` key, in case anyone is also relying on it. 👍🏻